### PR TITLE
yasuna.hから、memory.cに関する部分をmemory.hとして分割

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -1,6 +1,8 @@
 /*
  * yasuna - Yasuna Oribe will talk.
  *
+ * memory.c
+ *
  * Copyright (c) 2015 sasairc
  * This work is free. You can redistribute it and/or modify it under the
  * terms of the Do What The Fuck You Want To Public License, Version 2,
@@ -8,7 +10,7 @@
  * for more details.
  */
 
-#include "./yasuna.h"
+#include "./memory.h"
 #include <stdlib.h>
 
 char** malloc2d(int x, int y)
@@ -18,8 +20,7 @@ char** malloc2d(int x, int y)
 
     buf = (char**) malloc(sizeof(char*) * y);       /* Allocate array for Y coordinate */
     if (buf == NULL) {
-        fprintf(stderr, "%s: malloc2d(): malloc to (char**)var failure.\n", PROGNAME);
-        exit(7);
+        return NULL;
     }
     for (i = 0; i < y; i++) {
         buf[i] = (char*)malloc(sizeof(char) * x);   /* Allocate array for X coordinate */

--- a/memory.h
+++ b/memory.h
@@ -1,0 +1,21 @@
+/*
+ * yasuna - Yasuna Oribe will talk.
+ *
+ * memory.h
+ *
+ * Copyright (c) 2015 sasairc
+ * This work is free. You can redistribute it and/or modify it under the
+ * terms of the Do What The Fuck You Want To Public License, Version 2,
+ * as published by Sam Hocevar.HocevarHocevar See the COPYING file or http://www.wtfpl.net/
+ * for more details.
+ */
+
+#ifndef MEMORY_H
+#define MEMORY_H
+
+/* This functions is required memory.c */
+extern char** malloc2d(int x, int y);
+extern int init2d(char** buf, int x, int y);
+extern void free2d(char** buf, int y);
+
+#endif

--- a/yasuna.c
+++ b/yasuna.c
@@ -1,6 +1,8 @@
 /*
  * yasuna - Yasuna Oribe will talk.
  *
+ * yasuna.c
+ *
  * Copyright (c) 2015 sasairc
  * This work is free. You can redistribute it and/or modify it under the
  * terms of the Do What The Fuck You Want To Public License, Version 2,
@@ -9,6 +11,7 @@
  */
 
 #include "./yasuna.h"
+#include "./memory.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/yasuna.h
+++ b/yasuna.h
@@ -1,6 +1,8 @@
 /*
  * yasuna - Yasuna Oribe will talk.
  *
+ * yasuna.h
+ * 
  * Copyright (c) 2015 sasairc
  * This work is free. You can redistribute it and/or modify it under the
  * terms of the Do What The Fuck You Want To Public License, Version 2,
@@ -38,10 +40,5 @@ extern int print_usage();
 extern int check_file_type(char* filename);
 extern int read_file(int lines, char** buf, FILE* fp);
 extern int create_rand(int lines);
-
-/* This functions is required memory.c */
-//extern char** malloc2d(int x, int y);
-//extern int init2d(char** buf, int x, int y);
-extern void free2d(char** buf, int y);
 
 #endif


### PR DESCRIPTION
- `malloc2d()`、`init2d()`、`free2d()`の三つを分割
- `malloc2d()`失敗時に、戻り値としてNULLを返すように変更
