### PR TITLE
求

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ OBJS	= $(SRCS:.c=.o)
 all: $(TARGET) $(OBJS)
 
 DEFCFLAGS = -DPREFIX=\"$(PREFIX)\"  \
-			-DDICNAME=\"$(DICNME)\" \
-			-DDICPATH=\"$(DICDIR)/\"
+ 		-DDICNAME=\"$(DICNME)\" \
+		-DDICPATH=\"$(DICDIR)/\" \
 
 yasuna: $(OBJS)
 	$(CC) $(LDFLAGS) $(OBJS) -o $(TARGET)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 yasuna
 ======
-[![version](https://img.shields.io/badge/tag-7.0.0-orange.svg?style=flat)](https://github.com/sasairc/yasuna/releases)
+[![version](https://img.shields.io/badge/tag-7.1.0-orange.svg?style=flat)](https://github.com/sasairc/yasuna/releases)
 [![license](https://img.shields.io/badge/License-WTFPL2-blue.svg?style=flat)](http://www.wtfpl.net/txt/copying/)
 
 ![default](http://40.media.tumblr.com/07da53a3d6945721a4ca8aa4513b8277/tumblr_nizi5dPpPK1u2jamko1_1280.png)

--- a/file.c
+++ b/file.c
@@ -15,6 +15,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/time.h>
+#include <sys/select.h>
 
 int check_file_type(char* filename)
 {
@@ -112,17 +114,28 @@ char** p_read_file_char(int t_lines, size_t t_length, FILE* fp)
     char*   str     = (char*)malloc(sizeof(char) * t_length);   /* allocate temporary array */
     char**  buf     = (char**)malloc(sizeof(char*) * t_lines);  /* allocate array of Y coordinate */
 
-    if (str == NULL || buf == NULL)
+    if (str == NULL || buf == NULL) {
+
         return NULL;
+    } else if (t_lines == 0 || t_length == 0 || fp == NULL) {
+        free(str);
+        free(buf);
+
+        return NULL;
+    }
 
     while ((c = fgetc(fp)) != EOF) {
         switch (c) {
             case    '\n':
+                str[x] = c;
+
                 /* reallocate array of Y coordinate */
                 if (y == (lines - 1)) {
                     lines += t_lines;
-                    if ((buf = (char**)realloc(buf, sizeof(char*) * lines)) == NULL)
+                    if ((buf = (char**)realloc(buf, sizeof(char*) * lines)) == NULL) {
+
                         goto ERR;
+                    }
                 }
                 /* allocate array for X coordinate */
                 buf[y] = (char*)malloc(sizeof(char) * (strlen(str) + 1));
@@ -130,6 +143,7 @@ char** p_read_file_char(int t_lines, size_t t_length, FILE* fp)
                 for (i = 0; i < length; i++) {
                     str[i] = '\0';      /* refresh temporary array */
                 }
+
                 x = 0;
                 y++;
                 break;
@@ -137,13 +151,30 @@ char** p_read_file_char(int t_lines, size_t t_length, FILE* fp)
                 /* reallocate temporary array */
                 if (x == (length - 1)) {
                     length += t_length;
-                    if ((str = (char*)realloc(str, length)) == NULL)
+                    if ((str = (char*)realloc(str, length)) == NULL) {
+
                         goto ERR;
+                    }
                 }
+
                 str[x] = c;
                 x++;
                 continue;
         }
+    }
+
+    if (str[0] != '\0') {
+        if (y == (lines - 1)) {
+            str[x] = c;
+            lines += t_lines;
+            if ((buf = (char**)realloc(buf, sizeof(char*) * lines)) == NULL) {
+
+                goto ERR;
+            }
+        }
+        buf[y] = (char*)malloc(sizeof(char) * (strlen(str) + 1));
+        strcpy(buf[y], str);
+        y++;
     }
     buf[y] = NULL;
 
@@ -167,4 +198,17 @@ ERR:
         free(str);
 
     return NULL;
+}
+
+int watch_fd(int fd, long timeout)
+{
+    fd_set  fdset;
+    struct  timeval tm;
+
+    FD_ZERO(&fdset);
+    FD_SET(fd, &fdset);
+
+    tm.tv_sec = tm.tv_usec = timeout;
+
+    return select(fd+1, &fdset, NULL, NULL, &tm);
 }

--- a/file.c
+++ b/file.c
@@ -91,3 +91,80 @@ int read_file(int lines, size_t length, char** buf, FILE* fp)
 
     return i;
 }
+
+int p_count_file_lines(char** buf)
+{
+    int i;
+
+    for (i = 0; buf[i] != NULL; i++);
+
+    return i;
+}
+
+char** p_read_file_char(int t_lines, size_t t_length, FILE* fp)
+{
+    int     lines   = t_lines,
+            length  = t_length;
+    int     i       = 0,
+            x       = 0,
+            y       = 0;
+    char    c;
+    char*   str     = (char*)malloc(sizeof(char) * t_length);   /* allocate temporary array */
+    char**  buf     = (char**)malloc(sizeof(char*) * t_lines);  /* allocate array of Y coordinate */
+
+    if (str == NULL || buf == NULL)
+        return NULL;
+
+    while ((c = fgetc(fp)) != EOF) {
+        switch (c) {
+            case    '\n':
+                /* reallocate array of Y coordinate */
+                if (y == (lines - 1)) {
+                    lines += t_lines;
+                    if ((buf = (char**)realloc(buf, sizeof(char*) * lines)) == NULL)
+                        goto ERR;
+                }
+                /* allocate array for X coordinate */
+                buf[y] = (char*)malloc(sizeof(char) * (strlen(str) + 1));
+                strcpy(buf[y], str);    /* copy, str to buffer */
+                for (i = 0; i < length; i++) {
+                    str[i] = '\0';      /* refresh temporary array */
+                }
+                x = 0;
+                y++;
+                break;
+            default:
+                /* reallocate temporary array */
+                if (x == (length - 1)) {
+                    length += t_length;
+                    if ((str = (char*)realloc(str, length)) == NULL)
+                        goto ERR;
+                }
+                str[x] = c;
+                x++;
+                continue;
+        }
+    }
+    buf[y] = NULL;
+
+    return buf;
+
+
+ERR:
+    lines   -= t_lines;
+    length  -= t_length;
+
+    if (buf != NULL) {
+        for (i = 0; i < lines; i++) {
+            if (buf[i] != NULL) {
+                free(buf[i]);
+                buf[i] = NULL;
+            }
+        }
+        free(buf);
+    }
+    if (str != NULL)
+        free(str);
+
+    return NULL;
+}

--- a/file.c
+++ b/file.c
@@ -73,23 +73,19 @@ int count_file_lines(FILE* fp)
 int read_file(int lines, size_t length, char** buf, FILE* fp)
 {
     int     i = 0;
-    char*   str = (char*)malloc(sizeof(char) * length); /* Allocate buffer */
+    char*   str = (char*)malloc(sizeof(char) * length); /* allocate buffer */
 
     while (i <= lines && fgets(str, sizeof(char) * length, fp) != NULL) {
-        if (str[strlen(str) - 1] == '\n') { /* Checking string length */
-            /* 0: string < BUFLEN */
-            str[strlen(str) - 1] = '\0';
-            buf[i] = (char*)malloc(         /* Allocate array for X coordinate */
+        buf[i] = (char*)malloc(     /* allocate array for X coordinate */
                 (strlen(str) + 1) * sizeof(char)
             );
-            strcpy(buf[i], str);            /* Copy, str to buffer */
-        } else {
-            /* 1: string > BUFLEN */
+        if (buf[i] == NULL) {
             free(str);
-
+            
             return 0;
         }
-        i++;
+        strcpy(buf[i], str);        /* copy, str to buffer */
+        i++;                        /* count line */
     }
     free(str);
 

--- a/file.h
+++ b/file.h
@@ -1,14 +1,14 @@
 /*
  * yasuna - Yasuna Oribe will talk.
  *
- * file.h
+ * file.h 
  *
  * Copyright (c) 2015 sasairc
  * This work is free. You can redistribute it and/or modify it under the
  * terms of the Do What The Fuck You Want To Public License, Version 2,
  * as published by Sam Hocevar.HocevarHocevar See the COPYING file or http://www.wtfpl.net/
  * for more details.
- */ 
+ */
 
 #ifndef FILE_H
 #define FILE_H

--- a/file.h
+++ b/file.h
@@ -14,6 +14,7 @@
 #define FILE_H
 
 #include <stdio.h>
+#include <sys/time.h>
 
 /* This functions is required file.c */
 extern int check_file_type(char* filename);
@@ -21,5 +22,6 @@ extern int count_file_lines(FILE* fp);
 extern int read_file(int lines, size_t length, char** buf, FILE* fp);
 extern int p_count_file_lines(char** buf);
 extern char** p_read_file_char(int t_lines, size_t t_length, FILE* fp);
+extern int watch_fd(int fd, long timeout);
 
 #endif

--- a/file.h
+++ b/file.h
@@ -19,6 +19,7 @@
 extern int check_file_type(char* filename);
 extern int count_file_lines(FILE* fp);
 extern int read_file(int lines, size_t length, char** buf, FILE* fp);
-extern char* strlion(int argnum, ...);
+extern int p_count_file_lines(char** buf);
+extern char** p_read_file_char(int t_lines, size_t t_length, FILE* fp);
 
 #endif

--- a/string.c
+++ b/string.c
@@ -11,20 +11,28 @@
  */
 
 #include "./string.h"
+#include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#include <locale.h>
+
+#ifdef  WITH_GLIB
+#include <glib.h>
+#endif
 
 int strrep(char* src, char* haystack, char* needle)
 {
     char* find = NULL;
 
     if (src == NULL || haystack == NULL || needle == NULL) {
+
         return 1;
     }
 
     /* seach strings */
     if ((find = strstr(src, haystack)) == NULL) {
+
         return 3;       /* word not found */
     }
     if (strlen(haystack) < strlen(needle)) {
@@ -82,4 +90,103 @@ char* strlion(int argnum, ...)
     free(argmnt);
 
     return buf;
+}
+
+#ifdef  WITH_GLIB
+int mbstrlen(char* src)
+{
+    int         i    = 0;
+    int         ch   = 0;
+    int         len  = 0;
+    gunichar*   cpoints;
+
+    setlocale(LC_CTYPE, LOCALE);            /* set locale (string.h) */
+
+    while (src[i] != '\0') {
+        ch = mblen(&src[i], MB_CUR_MAX);    /* get string length */
+        if (ch > 1) {
+            cpoints = g_utf8_to_ucs4_fast(&src[i], sizeof(src[i]), NULL);   /* get unicode code point */
+
+            /*
+             * multi byte
+             * true : hankaku kana
+             * false: other
+             */
+            if (cpoints[0] >= 0xff65 && cpoints[0] <= 0xff9f) {
+                len++;
+            } else {
+                len += 2;
+            }
+
+            g_free(cpoints);
+        } else {
+            len++;                          /* ascii */
+        }
+        i += ch;                            /* seek offset */
+    }
+
+    return len;
+}
+#else
+int mbstrlen(char* src)
+{
+    int i = 0;
+    int ch = 0;
+    int len = 0;
+
+    setlocale(LC_CTYPE, LOCALE);            /* set locale (string.h) */
+
+    while (src[i] != '\0') {
+        ch = mblen(&src[i], MB_CUR_MAX);    /* get string length */
+        if (ch > 1) {
+            len += 2;                       /* multi byte */
+        } else {
+            len++;                          /* ascii */
+        }
+        i += ch;                            /* seek offset */
+    }
+
+    return len;
+}
+#endif
+
+int strunesc(char* src)
+{
+    int i = 0;
+    int count = 0;
+
+    while (src[i] != '\0') {
+        if (src[i] == '\t' || src[i] == '\b') {
+            src[i] = ' ';
+            count++;
+        }
+        i++;
+    }
+
+    return count;
+}
+            
+int strmax(int val, char** src)
+{
+    int i;
+    int len = 0;
+    int max = 0;
+
+    for (i = 0; i < val; i++) {
+        len = mbstrlen(src[i]);
+        if (max < len)  max = len;
+    }
+
+    return max;
+}
+
+int strlftonull(char* str)
+{
+    if (str[strlen(str) - 1] == '\n') {
+        str[strlen(str) - 1] = '\0';
+
+        return 1;
+    }
+
+    return 0;
 }

--- a/string.h
+++ b/string.h
@@ -10,11 +10,19 @@
  * for more details.
  */
 
+
 #ifndef YSTRING_H
 #define YSTRING_H
+
+//#define   WITH_GLIB   /* use glib */
+#define LOCALE "ja_JP.UTF-8"
 
 /* This functions is required string.c */
 extern int strrep(char* src, char* haystack, char* needle);
 extern char* strlion(int argnum, ...);
+extern int mbstrlen(char* src);
+extern int strunesc(char* src);
+extern int strmax(int val, char** src);
+extern int strlftonull(char* str);
 
 #endif

--- a/test.sh
+++ b/test.sh
@@ -5,17 +5,19 @@
 
 ARGS=("./yasuna" "--file" "quotes/yasuna-quotes")
 N=32
-Q=6144
+Q=4096
+
+echo "N = $N, Q = $Q"
 
 for ((i = 0; i < $N; i++)); do
-    echo -n "loop $i: "
-    for ((j = 1; j <= $Q; j++)); do
-        ${ARGS[@]} | \
-            grep null && \
-            echo "$j" && \
-            exit 1
-    done
-    echo "done."
+	echo -n "loop $i: "
+	for ((j = 1; j <= $Q; j++)); do
+		${ARGS[@]} | \
+			grep null && \
+			echo "$j" && \
+			exit 1
+	done
+	echo "done."
 done
 
 exit 0

--- a/yasuna.c
+++ b/yasuna.c
@@ -24,17 +24,16 @@
 
 int main(int argc, char* argv[])
 {
-    int     res,   index;   /* Use getopt_long() */
-    int     lines;          /* Text lines */
-    int     point   = 0;    /* Lines pointer */
+    int     res,   index;   /* use getopt_long() */
+    int     lines;          /* text lines */
+    int     point   = 0;    /* lines pointer */
     int     i       = 0;
-    char*   path    = NULL; /* Dictionary file path */
-    char**  buf     = NULL; /* String buffer */
+    char*   path    = NULL; /* dictionary file path */
+    char**  buf     = NULL; /* string buffer */
     FILE*   fp      = NULL; /* quotes file */
-    yasuna_t yasuna = {     /* Flag and args */
+    yasuna_t yasuna = {     /* flag and args */
         0, 0, 0, 0 ,NULL,
     };
-
     struct option opts[] = {
         {"file",    required_argument, NULL, 'f'},
         {"number",  required_argument, NULL, 'n'},
@@ -44,7 +43,7 @@ int main(int argc, char* argv[])
         {0, 0, 0, 0}
     };
 
-    /* Processing of arguments */
+    /* processing of arguments */
     while ((res = getopt_long(argc, argv, "f:n:lvh", opts, &index)) != -1) {
         switch (res) {
             case    'f':
@@ -73,7 +72,7 @@ int main(int argc, char* argv[])
         path = strlion(1, yasuna.farg); 
     } else {
 #ifdef  MONO
-        path = strlion(1, DICNAME);             /* With MONO build */
+        path = strlion(1, DICNAME);             /* with MONO build */
 #else
         path = strlion(2, DICPATH, DICNAME);
 #endif
@@ -94,11 +93,11 @@ int main(int argc, char* argv[])
         return 3;
     }
 
-    lines = count_file_lines(fp);                       /* Count line for text-file */
-    buf = (char**)malloc(sizeof(char*) * lines);        /* Allocate array for Y coordinate */
+    lines = count_file_lines(fp);                       /* count line for text-file */
+    buf = (char**)malloc(sizeof(char*) * lines);        /* allocate array for Y coordinate */
 
-    /* Reading file to array */
-    rewind(fp);                                         /* Seek file-strem to the top */
+    /* reading file to array */
+    rewind(fp);                                         /* seek file-strem to the top */
     if (read_file(lines, BUFLEN, buf, fp) == 0) {
         fprintf(
                 stderr,
@@ -109,8 +108,12 @@ int main(int argc, char* argv[])
 
         return 7;
     }
-    
-    /* Print all quotes list and exit */
+    for (i = 0; i < lines; i++)
+        strlftonull(buf[i]);    /* rf to null */
+
+    /* 
+     * print all quotes list and exit
+     */
     if (yasuna.lflag == 1) {
         for (i = 0; i < lines; i++) {
         fprintf(stdout, "%d %s\n", i, buf[i]);
@@ -122,13 +125,13 @@ int main(int argc, char* argv[])
 
     if (yasuna.nflag == 0) {
         do {
-            point = create_rand(lines);                 /* Get pseudo-random nuber */
+            point = create_rand(lines);                 /* get pseudo-random nuber */
         } while (buf[point] == NULL);
     } else {
         if (lines >= yasuna.narg)   point = yasuna.narg;
     }
 
-    fprintf(stdout, "%s\n", buf[point]);                /* Print of string */
+    fprintf(stdout, "%s\n", buf[point]);                /* print of string */
     release(fp, path, lines, buf);                      /* release memory */
 
     return 0;
@@ -136,9 +139,9 @@ int main(int argc, char* argv[])
 
 int check_file_stat(char* path)
 {
-    struct  stat st;        /* File status */
+    struct  stat st;        /* file status */
 
-    /* Checking type of file or directory */
+    /* checking type of file or directory */
     if (stat(path, &st) != 0) {
         fprintf(stderr, "%s: %s: no such file or directory\n", PROGNAME, path);
 
@@ -150,7 +153,7 @@ int check_file_stat(char* path)
         return 2;
     }
 
-    /* Checking file permission */
+    /* checking file permission */
     if (access(path, R_OK) != 0) {
         fprintf(stderr, "%s: %s: permission denied\n", PROGNAME, path);
 
@@ -164,7 +167,7 @@ FILE* open_file(char* path)
 {
     FILE* fp;
 
-    /* Open after checking file type */
+    /* open after checking file type */
     if (check_file_type(path) == 0) {
         fp = fopen(path, "r");
     } else {
@@ -200,17 +203,17 @@ int create_rand(int lines)
     int ret;
     struct timeval lo_timeval;
 
-    gettimeofday(&lo_timeval, NULL);    /* Get localtime */
+    gettimeofday(&lo_timeval, NULL);    /* get localtime */
 
     /* 
-     * # Setting factor for pseudo-random number
-     * Current microseconds * PID
+     * # setting factor for pseudo-random number
+     * current microseconds * PID
      */
     srand((unsigned)(
         lo_timeval.tv_usec * getpid()
     ));
 
-    ret = (int)(rand()%(lines+1));      /* Create pseudo-random number */
+    ret = (int)(rand()%(lines+1));      /* create pseudo-random number */
 
     return ret;
 }

--- a/yasuna.c
+++ b/yasuna.c
@@ -92,31 +92,27 @@ int main(int argc, char* argv[])
 
         return 3;
     }
-
-    lines = count_file_lines(fp);                       /* count line for text-file */
-    buf = (char**)malloc(sizeof(char*) * lines);        /* allocate array for Y coordinate */
-
-    /* reading file to array */
-    rewind(fp);                                         /* seek file-strem to the top */
-    if (read_file(lines, BUFLEN, buf, fp) == 0) {
+    if ((buf = p_read_file_char(TH_LINES, TH_LENGTH, fp)) == NULL) {
         fprintf(
                 stderr,
-                "%s: capacity of buffer is not enough: BUFLEN=%d\n",
-                PROGNAME, BUFLEN
+                "%s: p_read_file_char() failure\n",
+                PROGNAME
         );
-        release(fp, path, lines, buf);
-
+        release(fp, path, 0, NULL);
+            
         return 7;
     }
+    lines = p_count_file_lines(buf);            /* count line for text-file */
+
     for (i = 0; i < lines; i++)
-        strlftonull(buf[i]);    /* rf to null */
+        strlftonull(buf[i]);                    /* rf to null */
 
     /* 
      * print all quotes list and exit
      */
     if (yasuna.lflag == 1) {
         for (i = 0; i < lines; i++) {
-        fprintf(stdout, "%d %s\n", i, buf[i]);
+        fprintf(stdout, "%4d %s\n", i, buf[i]);
         }
         release(fp, path, lines, buf);
 
@@ -125,14 +121,14 @@ int main(int argc, char* argv[])
 
     if (yasuna.nflag == 0) {
         do {
-            point = create_rand(lines);                 /* get pseudo-random nuber */
+            point = create_rand(lines);         /* get pseudo-random nuber */
         } while (buf[point] == NULL);
     } else {
         if (lines >= yasuna.narg)   point = yasuna.narg;
     }
 
-    fprintf(stdout, "%s\n", buf[point]);                /* print of string */
-    release(fp, path, lines, buf);                      /* release memory */
+    fprintf(stdout, "%s\n", buf[point]);        /* print of string */
+    release(fp, path, lines, buf);              /* release memory */
 
     return 0;
 }
@@ -196,6 +192,8 @@ void release(FILE* fp, char* path, int lines, char** buf)
     if (buf != NULL) {
         free2d(buf, lines);
     }
+
+    return;
 }
 
 int create_rand(int lines)

--- a/yasuna.h
+++ b/yasuna.h
@@ -23,8 +23,15 @@
 #define AUTHOR      "sasairc"
 #define MAIL_TO     "sasairc@ssiserver.moe.hm"
 
-//#define MONO        /* パスを組み込みたくないときに使うといいかもネ */
-#define BUFLEN      512
+/*
+ * # setting of realloc() timing
+ * TH_LINES  : threshold of lines
+ * TH_LENGTH : threshold of string (sizeof(char) * TH_LENGTH)
+ */
+#define TH_LINES    512 
+#define TH_LENGTH   512
+
+//#define MONO              /* パスを組み込みたくないときに使うといいかもネ */
 
 typedef struct YASUNA_T {
     int lflag;      /* List flag(--list). */

--- a/yasuna.h
+++ b/yasuna.h
@@ -17,7 +17,7 @@
 
 #define PROGNAME    "yasuna"
 #define VERSION     7
-#define PATCHLEVEL  0
+#define PATCHLEVEL  1
 #define SUBLEVEL    0
 
 #define AUTHOR      "sasairc"


### PR DESCRIPTION
- 8d3b77c `p_read_file_char()`と`p_count_file_lines()`を使用するように変更
  3cfdc79 `p_read_file_char()`と`p_count_file_lines()`を作成  
  ファイルを読み込む際に行単位ではなく、1バイトごとに読むように変更。
  それに伴い、`yasuna.h`の`TH_LINES`と`TH_LENGTH`の値をタイミングとして、`realloc()`でメモリを拡張するように。
- 35e4ba1 modified: test.sh (テスト用)
- c96c9b4 インデント調整
- 8a2dacd `main()`内から`strlfnull()`を呼ぶように変更
- 28d75fe 文字列末尾のLFをNULLに置き換えする為に`strlftonull()`を作成
- 10155e3 `read_file()`から文字列末尾のLF->NULL置き換え処理を削除
